### PR TITLE
댓글 API 구현 및 수정 / 댓글 API Controller, Service 테스트 구현 (나머지 기능 구현 예정)

### DIFF
--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -24,4 +24,12 @@ public class CommentController {
 
     commentService.save(postId, userContext, request);
   }
+
+  @PostMapping("/posts/{postId}/comments/{commentId}/reply")
+  public void saveReply(@PathVariable Long postId, @PathVariable Long commentId,
+      @AuthenticationPrincipal UserContext userContext,
+      @Valid @RequestBody CommentSaveRequest request) {
+
+    commentService.saveReply(postId, commentId, userContext, request);
+  }
 }

--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.blog.tanylog.config.security.UserContext;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,5 +32,12 @@ public class CommentController {
       @Valid @RequestBody CommentSaveRequest request) {
 
     commentService.saveReply(postId, commentId, userContext, request);
+  }
+
+  @DeleteMapping("/comments/{commentId}")
+  public void delete(@PathVariable Long commentId,
+      @AuthenticationPrincipal UserContext userContext) {
+
+    commentService.delete(commentId, userContext);
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/domain/Comment.java
+++ b/src/main/java/com/blog/tanylog/comment/domain/Comment.java
@@ -71,6 +71,10 @@ public class Comment extends BaseEntity {
     return true;
   }
 
+  public boolean checkUser(User loginUser) {
+    return this.user.getOauthId().equals(loginUser.getOauthId());
+  }
+
   public void addDepth() {
     this.replyDepth += 1;
   }

--- a/src/main/java/com/blog/tanylog/comment/domain/Comment.java
+++ b/src/main/java/com/blog/tanylog/comment/domain/Comment.java
@@ -40,6 +40,8 @@ public class Comment extends BaseEntity {
 
   private boolean isDeleted;
 
+  private int replyDepth;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;
@@ -61,11 +63,27 @@ public class Comment extends BaseEntity {
     this.isDeleted = isDeleted;
   }
 
+  public boolean checkDepth() {
+    if (this.replyDepth > 0) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public void addDepth() {
+    this.replyDepth += 1;
+  }
+
   public void addUser(User user) {
     this.user = user;
   }
 
   public void addPost(Post post) {
     this.post = post;
+  }
+
+  public void addParentComment(Comment parentComment) {
+    this.parentComment = parentComment;
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/domain/Comment.java
+++ b/src/main/java/com/blog/tanylog/comment/domain/Comment.java
@@ -83,7 +83,8 @@ public class Comment extends BaseEntity {
     this.post = post;
   }
 
-  public void addParentComment(Comment parentComment) {
+  public void addRelationByComment(Comment parentComment) {
     this.parentComment = parentComment;
+    parentComment.childComments.add(this);
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentRepository.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentRepository.java
@@ -2,7 +2,13 @@ package com.blog.tanylog.comment.repository;
 
 import com.blog.tanylog.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE Comment c SET c.isDeleted = true WHERE c.id = :commentId OR c.parentComment.id = :commentId")
+  void deleteComment(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentRepository.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentRepository.java
@@ -1,12 +1,8 @@
 package com.blog.tanylog.comment.repository;
 
 import com.blog.tanylog.comment.domain.Comment;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-  @Query("SELECT c FROM Comment c JOIN FETCH c.user JOIN FETCH c.post")
-  List<Comment> findAll();
 }

--- a/src/main/java/com/blog/tanylog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/tanylog/comment/service/CommentService.java
@@ -4,6 +4,8 @@ import com.blog.tanylog.comment.controller.dto.request.CommentSaveRequest;
 import com.blog.tanylog.comment.domain.Comment;
 import com.blog.tanylog.comment.repository.CommentRepository;
 import com.blog.tanylog.config.security.UserContext;
+import com.blog.tanylog.global.exception.domain.CommentDepthOverException;
+import com.blog.tanylog.global.exception.domain.CommentNotFound;
 import com.blog.tanylog.global.exception.domain.PostNotFound;
 import com.blog.tanylog.global.exception.domain.UserNotFound;
 import com.blog.tanylog.post.domain.Post;
@@ -37,6 +39,35 @@ public class CommentService {
     Comment comment = request.toEntity(content, isDeleted);
     comment.addUser(loginUser);
     comment.addPost(ownerPost);
+
+    commentRepository.save(comment);
+  }
+
+  @Transactional
+  public void saveReply(Long postId, Long commentId, UserContext userContext,
+      CommentSaveRequest request) {
+    Long userId = userContext.getSessionUser().getUserId();
+    User loginUser = userRepository.findById(userId)
+        .orElseThrow(UserNotFound::new);
+
+    Post ownerPost = postRepository.findById(postId)
+        .orElseThrow(PostNotFound::new);
+
+    Comment parentComment = commentRepository.findById(commentId)
+        .orElseThrow(CommentNotFound::new);
+
+    if (!parentComment.checkDepth()) {
+      throw new CommentDepthOverException();
+    }
+
+    String content = request.getContent();
+    boolean isDeleted = request.isDeleted();
+
+    Comment comment = request.toEntity(content, isDeleted);
+    comment.addDepth();
+    comment.addUser(loginUser);
+    comment.addPost(ownerPost);
+    comment.addParentComment(parentComment);
 
     commentRepository.save(comment);
   }

--- a/src/main/java/com/blog/tanylog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/tanylog/comment/service/CommentService.java
@@ -63,12 +63,12 @@ public class CommentService {
     String content = request.getContent();
     boolean isDeleted = request.isDeleted();
 
-    Comment comment = request.toEntity(content, isDeleted);
-    comment.addDepth();
-    comment.addUser(loginUser);
-    comment.addPost(ownerPost);
-    comment.addParentComment(parentComment);
+    Comment replyComment = request.toEntity(content, isDeleted);
+    replyComment.addDepth();
+    replyComment.addUser(loginUser);
+    replyComment.addPost(ownerPost);
+    replyComment.addRelationByComment(parentComment);
 
-    commentRepository.save(comment);
+    commentRepository.save(replyComment);
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/tanylog/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.blog.tanylog.comment.repository.CommentRepository;
 import com.blog.tanylog.config.security.UserContext;
 import com.blog.tanylog.global.exception.domain.CommentDepthOverException;
 import com.blog.tanylog.global.exception.domain.CommentNotFound;
+import com.blog.tanylog.global.exception.domain.OtherUserDeleteException;
 import com.blog.tanylog.global.exception.domain.PostNotFound;
 import com.blog.tanylog.global.exception.domain.UserNotFound;
 import com.blog.tanylog.post.domain.Post;
@@ -70,5 +71,21 @@ public class CommentService {
     replyComment.addRelationByComment(parentComment);
 
     commentRepository.save(replyComment);
+  }
+
+  @Transactional
+  public void delete(Long commentId, UserContext userContext) {
+    Long userId = userContext.getSessionUser().getUserId();
+    User loginUser = userRepository.findById(userId)
+        .orElseThrow(UserNotFound::new);
+
+    Comment findComment = commentRepository.findById(commentId)
+        .orElseThrow(CommentNotFound::new);
+
+    if (!findComment.checkUser(loginUser)) {
+      throw new OtherUserDeleteException();
+    }
+
+    commentRepository.deleteComment(findComment.getId());
   }
 }

--- a/src/main/java/com/blog/tanylog/config/security/SecurityConfig.java
+++ b/src/main/java/com/blog/tanylog/config/security/SecurityConfig.java
@@ -25,6 +25,8 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.POST, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.DELETE, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.PUT, "/posts/**").hasAnyRole("ADMIN", "USER")
+
+        .antMatchers(HttpMethod.DELETE, "/comments/**").hasAnyRole("ADMIN", "USER")
         .anyRequest().permitAll()
 
         .and()

--- a/src/main/java/com/blog/tanylog/global/exception/domain/CommentDepthOverException.java
+++ b/src/main/java/com/blog/tanylog/global/exception/domain/CommentDepthOverException.java
@@ -1,0 +1,16 @@
+package com.blog.tanylog.global.exception.domain;
+
+public class CommentDepthOverException extends GlobalException {
+
+  private static final String MESSAGE = "대댓글에는 대댓글을 작성할 수 없습니다.";
+
+  public CommentDepthOverException() {
+    super(MESSAGE);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return 400;
+  }
+
+}

--- a/src/main/java/com/blog/tanylog/global/exception/domain/CommentNotFound.java
+++ b/src/main/java/com/blog/tanylog/global/exception/domain/CommentNotFound.java
@@ -1,0 +1,15 @@
+package com.blog.tanylog.global.exception.domain;
+
+public class CommentNotFound extends GlobalException {
+
+  private static final String MESSAGE = "존재하지 않는 게시글입니다.";
+
+  public CommentNotFound() {
+    super(MESSAGE);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return 404;
+  }
+}

--- a/src/main/java/com/blog/tanylog/post/repository/PostRepository.java
+++ b/src/main/java/com/blog/tanylog/post/repository/PostRepository.java
@@ -4,9 +4,10 @@ import com.blog.tanylog.post.domain.Post;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 
-  @Query("SELECT p FROM Post p JOIN FETCH p.user")
-  Optional<Post> findById(Long postId);
+  @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.id = :postId")
+  Optional<Post> findById(@Param("postId") Long postId);
 }

--- a/src/main/java/com/blog/tanylog/post/repository/PostRepository.java
+++ b/src/main/java/com/blog/tanylog/post/repository/PostRepository.java
@@ -4,10 +4,9 @@ import com.blog.tanylog.post.domain.Post;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 
   @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.id = :postId")
-  Optional<Post> findById(@Param("postId") Long postId);
+  Optional<Post> findByPostId(Long postId);
 }

--- a/src/main/java/com/blog/tanylog/post/service/PostService.java
+++ b/src/main/java/com/blog/tanylog/post/service/PostService.java
@@ -50,7 +50,7 @@ public class PostService {
     User loginUser = userRepository.findById(userId)
         .orElseThrow(UserNotFound::new);
 
-    Post findPost = postRepository.findById(postId)
+    Post findPost = postRepository.findByPostId(postId)
         .orElseThrow(PostNotFound::new);
 
     if (!findPost.checkUser(loginUser)) {
@@ -66,7 +66,7 @@ public class PostService {
     User loginUser = userRepository.findById(userId)
         .orElseThrow(UserNotFound::new);
 
-    Post findPost = postRepository.findById(postId)
+    Post findPost = postRepository.findByPostId(postId)
         .orElseThrow(PostNotFound::new);
 
     if (!findPost.checkUser(loginUser)) {
@@ -82,7 +82,7 @@ public class PostService {
   // GET Method 에 Transactional 을 꼭 사용해야할까 ?
   @Transactional
   public PostSingleReadResponse read(Long postId) {
-    Post findPost = postRepository.findById(postId)
+    Post findPost = postRepository.findByPostId(postId)
         .orElseThrow(PostNotFound::new);
 
     User user = findPost.getUser();

--- a/src/test/java/com/blog/tanylog/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/blog/tanylog/comment/controller/CommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.blog.tanylog.comment.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -64,5 +65,16 @@ class CommentControllerTest {
             .content(mapper.writeValueAsString(request)))
         .andDo(print())
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("비회원 상태로 댓글을 삭제할 수는 없습니다.")
+  void 비회원_댓글_삭제_Redirect() throws Exception {
+    Long commentId = 1L;
+
+    mockMvc.perform(delete("/comments/{commentId}", commentId)
+            .with(csrf()))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection());
   }
 }

--- a/src/test/java/com/blog/tanylog/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/blog/tanylog/comment/service/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package com.blog.tanylog.comment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.blog.tanylog.comment.controller.dto.request.CommentSaveRequest;
 import com.blog.tanylog.comment.domain.Comment;
@@ -8,6 +9,7 @@ import com.blog.tanylog.comment.repository.CommentRepository;
 import com.blog.tanylog.config.DatabaseCleanup;
 import com.blog.tanylog.config.WithMockCustomUser;
 import com.blog.tanylog.config.security.UserContext;
+import com.blog.tanylog.global.exception.domain.CommentDepthOverException;
 import com.blog.tanylog.post.domain.Post;
 import com.blog.tanylog.post.repository.PostRepository;
 import com.blog.tanylog.user.domain.Role;
@@ -61,6 +63,16 @@ class CommentServiceTest {
     post.addUser(user);
 
     postRepository.save(post);
+
+    Comment comment = commentRepository.save(Comment.builder()
+        .content("test content")
+        .isDeleted(false)
+        .build());
+
+    comment.addUser(user);
+    comment.addPost(post);
+
+    commentRepository.save(comment);
   }
 
   @AfterEach
@@ -88,8 +100,59 @@ class CommentServiceTest {
 
     // then
     List<Comment> findComments = commentRepository.findAll();
-    assertThat(findComments.size()).isEqualTo(1);
-    assertThat(findComments.get(0).getPost().getId()).isEqualTo(1L);
-    assertThat(findComments.get(0).getPost().getContent()).isEqualTo("dummy_content");
+    assertThat(findComments.size()).isEqualTo(2);
+    assertThat(findComments.stream().allMatch(comment -> comment.getReplyDepth() == 0)).isTrue();
+  }
+
+  @Test
+  @DisplayName("USER 권한의 유저는 대댓글을 등록할 수 있습니다.")
+  @WithMockCustomUser
+  void 대댓글_등록() {
+    // given
+    Long postId = 1L;
+    Long commentId = 1L;
+
+    UserContext userContext = (UserContext) SecurityContextHolder.getContext().getAuthentication()
+        .getPrincipal();
+
+    CommentSaveRequest request = CommentSaveRequest.builder()
+        .content("reply content")
+        .isDeleted(false)
+        .build();
+
+    // when
+    commentService.saveReply(postId, commentId, userContext, request);
+
+    // then
+    List<Comment> findComments = commentRepository.findAll();
+    assertThat(findComments.size()).isEqualTo(2);
+    assertThat(findComments.get(1).getParentComment().getId()).isEqualTo(1L);
+    assertThat(findComments.get(1).getReplyDepth()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("대댓글에는 대댓글을 작성할 수 없습니다.")
+  @WithMockCustomUser
+  void 무한_대댓글_작성_제한() {
+    // given
+    Long postId = 1L;
+    Long commentId = 1L;
+
+    UserContext userContext = (UserContext) SecurityContextHolder.getContext().getAuthentication()
+        .getPrincipal();
+
+    CommentSaveRequest request = CommentSaveRequest.builder()
+        .content("reply content")
+        .isDeleted(false)
+        .build();
+
+    // when
+    commentService.saveReply(postId, commentId, userContext, request);
+    List<Comment> comments = commentRepository.findAll();
+
+    // then
+    assertThrows(CommentDepthOverException.class,
+        () -> commentService.saveReply(postId, comments.get(comments.size() - 1).getId(),
+            userContext, request));
   }
 }

--- a/src/test/java/com/blog/tanylog/config/TestSecurityConfig.java
+++ b/src/test/java/com/blog/tanylog/config/TestSecurityConfig.java
@@ -22,6 +22,8 @@ public class TestSecurityConfig {
         .antMatchers(HttpMethod.POST, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.DELETE, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.PUT, "/posts/**").hasAnyRole("ADMIN", "USER")
+
+        .antMatchers(HttpMethod.DELETE, "/comments/**").hasAnyRole("ADMIN", "USER")
         .anyRequest().permitAll()
 
         .and()

--- a/src/test/java/com/blog/tanylog/post/service/PostServiceTest.java
+++ b/src/test/java/com/blog/tanylog/post/service/PostServiceTest.java
@@ -101,7 +101,7 @@ class PostServiceTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("test_title");
+    assertThat(response.getTitle()).isEqualTo("dummy_title");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- 댓글, 대댓글 API 구현 및 Controller, Service 테스트 작성

## Description
- ***API 구현***
  - [x] 댓글, 대댓글 등록 API 수정
    - 대댓글에 대한 대댓글은 없도록 수정 (무한 대댓글 방지)
  - [x] 댓글 삭제 API 구현
    - Soft Delete 방식 구현
    - 부모 댓글 : 자식 댓글 (1:N) 관계 N + 1 문제가 발생하지 않도록 전역 배치 사이즈 설정 (100)
    - Soft Delete 이기 때문에 UPDATE 쿼리가 한 번에 발생할 수 있도록 Bulk Update 방식으로 구현

- ***API 테스트***
  - [x] 댓글, 대댓글 등록 API 테스트
  - [x] 댓글, 대댓글 삭제 API 테스트
  - [x] 비회원 Redirect 테스트
  - [x] 유효성 검사 테스트
