### PR TITLE
댓글 수정, 전체 조회 및 대댓글 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -26,8 +26,7 @@ public class CommentController {
   private final CommentService commentService;
 
   @PostMapping("/posts/{postId}/comments")
-  public void save(@PathVariable Long postId,
-      @AuthenticationPrincipal UserContext userContext,
+  public void save(@PathVariable Long postId, @AuthenticationPrincipal UserContext userContext,
       @Valid @RequestBody CommentSaveRequest request) {
 
     commentService.save(postId, userContext, request);
@@ -61,6 +60,16 @@ public class CommentController {
       @ModelAttribute CommentPageSearch commentPageSearch) {
 
     CommentMultiReadResponse response = commentService.readAll(postId, commentPageSearch);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/posts/{postId}/comments/{commentId}")
+  public ResponseEntity<CommentMultiReadResponse> readReplyAll(@PathVariable Long postId,
+      @PathVariable Long commentId, @ModelAttribute CommentPageSearch commentPageSearch) {
+
+    CommentMultiReadResponse response = commentService.readReplyAll(postId, commentId,
+        commentPageSearch);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.blog.tanylog.comment.controller;
 
 import com.blog.tanylog.comment.controller.dto.request.CommentSaveRequest;
+import com.blog.tanylog.comment.controller.dto.request.CommentUpdateRequest;
 import com.blog.tanylog.comment.service.CommentService;
 import com.blog.tanylog.config.security.UserContext;
 import javax.validation.Valid;
@@ -9,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,5 +41,13 @@ public class CommentController {
       @AuthenticationPrincipal UserContext userContext) {
 
     commentService.delete(commentId, userContext);
+  }
+
+  @PutMapping("/posts/{postId}/comments/{commentId}")
+  public void update(@PathVariable Long postId, @PathVariable Long commentId,
+      @AuthenticationPrincipal UserContext userContext,
+      @Valid @RequestBody CommentUpdateRequest request) {
+
+    commentService.update(postId, commentId, userContext, request);
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -1,13 +1,18 @@
 package com.blog.tanylog.comment.controller;
 
+import com.blog.tanylog.comment.controller.dto.request.CommentPageSearch;
 import com.blog.tanylog.comment.controller.dto.request.CommentSaveRequest;
 import com.blog.tanylog.comment.controller.dto.request.CommentUpdateRequest;
+import com.blog.tanylog.comment.controller.dto.response.CommentMultiReadResponse;
 import com.blog.tanylog.comment.service.CommentService;
 import com.blog.tanylog.config.security.UserContext;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -49,5 +54,14 @@ public class CommentController {
       @Valid @RequestBody CommentUpdateRequest request) {
 
     commentService.update(postId, commentId, userContext, request);
+  }
+
+  @GetMapping("/posts/{postId}/comments")
+  public ResponseEntity<CommentMultiReadResponse> readAll(@PathVariable Long postId,
+      @ModelAttribute CommentPageSearch commentPageSearch) {
+
+    CommentMultiReadResponse response = commentService.readAll(postId, commentPageSearch);
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/controller/dto/request/CommentPageSearch.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/dto/request/CommentPageSearch.java
@@ -1,0 +1,17 @@
+package com.blog.tanylog.comment.controller.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CommentPageSearch {
+
+  private static final int MAX_SIZE = 2000;
+
+  private final Long lastRecordId;
+  private final Integer size;
+
+  public CommentPageSearch(Long lastRecordId, Integer size) {
+    this.lastRecordId = lastRecordId;
+    this.size = (size != null) ? size : 5;
+  }
+}

--- a/src/main/java/com/blog/tanylog/comment/controller/dto/request/CommentPageSearch.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/dto/request/CommentPageSearch.java
@@ -12,6 +12,6 @@ public class CommentPageSearch {
 
   public CommentPageSearch(Long lastRecordId, Integer size) {
     this.lastRecordId = lastRecordId;
-    this.size = (size != null) ? size : 5;
+    this.size = (size != null) ? size : 10;
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/controller/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.blog.tanylog.comment.controller.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentUpdateRequest {
+
+  @NotBlank(message = "내용은 비울 수 없습니다.")
+  private String content;
+
+  @Builder
+  public CommentUpdateRequest(String content) {
+    this.content = content;
+  }
+}

--- a/src/main/java/com/blog/tanylog/comment/controller/dto/response/CommentMultiReadResponse.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/dto/response/CommentMultiReadResponse.java
@@ -1,0 +1,16 @@
+package com.blog.tanylog.comment.controller.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentMultiReadResponse {
+
+  private final List<CommentSingleReadResponse> commentsResponse;
+
+  @Builder
+  public CommentMultiReadResponse(List<CommentSingleReadResponse> commentsResponse) {
+    this.commentsResponse = commentsResponse;
+  }
+}

--- a/src/main/java/com/blog/tanylog/comment/controller/dto/response/CommentSingleReadResponse.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/dto/response/CommentSingleReadResponse.java
@@ -1,0 +1,26 @@
+package com.blog.tanylog.comment.controller.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentSingleReadResponse {
+
+  private final Long id;
+  private final String content;
+  private final LocalDateTime createdDate;
+  private final LocalDateTime modifiedDate;
+  private final CommentWriterResponse writer;
+
+  @Builder
+  public CommentSingleReadResponse(Long id,
+      CommentWriterResponse writer, LocalDateTime createdDate, LocalDateTime modifiedDate,
+      String content) {
+    this.id = id;
+    this.writer = writer;
+    this.createdDate = createdDate;
+    this.modifiedDate = modifiedDate;
+    this.content = content;
+  }
+}

--- a/src/main/java/com/blog/tanylog/comment/controller/dto/response/CommentWriterResponse.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/dto/response/CommentWriterResponse.java
@@ -1,0 +1,20 @@
+package com.blog.tanylog.comment.controller.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentWriterResponse {
+
+  private final String name;
+  private final String email;
+  private final String picture;
+
+  @Builder
+  public CommentWriterResponse(String name, String email, String picture) {
+    this.name = name;
+    this.email = email;
+    this.picture = picture;
+  }
+}
+

--- a/src/main/java/com/blog/tanylog/comment/domain/Comment.java
+++ b/src/main/java/com/blog/tanylog/comment/domain/Comment.java
@@ -75,6 +75,10 @@ public class Comment extends BaseEntity {
     return this.user.getOauthId().equals(loginUser.getOauthId());
   }
 
+  public void updateComment(String updateContent) {
+    this.content = updateContent;
+  }
+
   public void addDepth() {
     this.replyDepth += 1;
   }

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentCustomRepository.java
@@ -1,0 +1,10 @@
+package com.blog.tanylog.comment.repository;
+
+import com.blog.tanylog.comment.controller.dto.request.CommentPageSearch;
+import com.blog.tanylog.comment.domain.Comment;
+import java.util.List;
+
+public interface CommentCustomRepository {
+
+  List<Comment> readNoOffset(Long postId, CommentPageSearch commentPageSearch);
+}

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentCustomRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface CommentCustomRepository {
 
   List<Comment> readNoOffset(Long postId, CommentPageSearch commentPageSearch);
+
+  List<Comment> readReplyNoOffset(Long postId, Long commentId, CommentPageSearch commentPageSearch);
 }

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentRepository.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentCustomRepository {
 
   @Modifying(clearAutomatically = true)
   @Query("UPDATE Comment c SET c.isDeleted = true WHERE c.id = :commentId OR c.parentComment.id = :commentId")

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.blog.tanylog.comment.repository;
+
+import com.blog.tanylog.comment.controller.dto.request.CommentPageSearch;
+import com.blog.tanylog.comment.domain.Comment;
+import com.blog.tanylog.comment.domain.QComment;
+import com.blog.tanylog.post.domain.QPost;
+import com.blog.tanylog.user.domain.QUser;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentCustomRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<Comment> readNoOffset(Long postId, CommentPageSearch commentPageSearch) {
+    Long id = commentPageSearch.getLastRecordId();
+
+    BooleanBuilder dynamicLtId = new BooleanBuilder();
+
+    // 동적 쿼리 설정
+    if (id != null) {
+      dynamicLtId.and(QComment.comment.id.gt(id));
+    }
+
+    return jpaQueryFactory.select(QComment.comment)
+        .from(QComment.comment)
+        .join(QComment.comment.user, QUser.user).fetchJoin()
+        .join(QComment.comment.post, QPost.post).fetchJoin()
+        .where(dynamicLtId.and(QComment.comment.isDeleted.eq(false))
+            .and(QComment.comment.post.id.eq(postId))
+            .and(QComment.comment.replyDepth.eq(0)))
+        .orderBy(QComment.comment.id.desc())
+        .limit(commentPageSearch.getSize())
+        .fetch();
+  }
+}
+

--- a/src/main/java/com/blog/tanylog/post/controller/dto/response/PostSingleReadResponse.java
+++ b/src/main/java/com/blog/tanylog/post/controller/dto/response/PostSingleReadResponse.java
@@ -12,11 +12,11 @@ public class PostSingleReadResponse {
   private final String content;
   private final LocalDateTime createdDate;
   private final LocalDateTime modifiedDate;
-  private final WriterResponse writer;
+  private final PostWriterResponse writer;
 
   @Builder
   public PostSingleReadResponse(Long id, String title, String content,
-      LocalDateTime createdDate, LocalDateTime modifiedDate, WriterResponse writer) {
+      LocalDateTime createdDate, LocalDateTime modifiedDate, PostWriterResponse writer) {
     this.id = id;
     this.title = title;
     this.content = content;

--- a/src/main/java/com/blog/tanylog/post/controller/dto/response/PostWriterResponse.java
+++ b/src/main/java/com/blog/tanylog/post/controller/dto/response/PostWriterResponse.java
@@ -4,14 +4,14 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class WriterResponse {
+public class PostWriterResponse {
 
   private final String name;
   private final String email;
   private final String picture;
 
   @Builder
-  public WriterResponse(String name, String email, String picture) {
+  public PostWriterResponse(String name, String email, String picture) {
     this.name = name;
     this.email = email;
     this.picture = picture;

--- a/src/main/java/com/blog/tanylog/post/service/PostService.java
+++ b/src/main/java/com/blog/tanylog/post/service/PostService.java
@@ -10,7 +10,7 @@ import com.blog.tanylog.post.controller.dto.request.PostSaveRequest;
 import com.blog.tanylog.post.controller.dto.request.PostUpdateRequest;
 import com.blog.tanylog.post.controller.dto.response.PostMultiReadResponse;
 import com.blog.tanylog.post.controller.dto.response.PostSingleReadResponse;
-import com.blog.tanylog.post.controller.dto.response.WriterResponse;
+import com.blog.tanylog.post.controller.dto.response.PostWriterResponse;
 import com.blog.tanylog.post.domain.Post;
 import com.blog.tanylog.post.repository.PostRepository;
 import com.blog.tanylog.user.domain.User;
@@ -87,7 +87,7 @@ public class PostService {
 
     User user = findPost.getUser();
 
-    WriterResponse writer = WriterResponse.builder()
+    PostWriterResponse writer = PostWriterResponse.builder()
         .name(user.getName())
         .email(user.getEmail())
         .picture(user.getPicture())
@@ -114,7 +114,7 @@ public class PostService {
             .content(post.getContent())
             .createdDate(post.getCreateAt())
             .modifiedDate(post.getModifiedAt())
-            .writer(WriterResponse.builder()
+            .writer(PostWriterResponse.builder()
                 .name(post.getUser().getName())
                 .email(post.getUser().getEmail())
                 .picture(post.getUser().getPicture())

--- a/src/test/java/com/blog/tanylog/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/blog/tanylog/comment/controller/CommentControllerTest.java
@@ -3,10 +3,12 @@ package com.blog.tanylog.comment.controller;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.blog.tanylog.comment.controller.dto.request.CommentSaveRequest;
+import com.blog.tanylog.comment.controller.dto.request.CommentUpdateRequest;
 import com.blog.tanylog.comment.service.CommentService;
 import com.blog.tanylog.config.TestSecurityConfig;
 import com.blog.tanylog.config.WithMockCustomUser;
@@ -35,7 +37,7 @@ class CommentControllerTest {
 
   @Test
   @DisplayName("비회원 상태로 댓글을 등록할 수는 없습니다.")
-  void 비회원_게시글_등록_Redirect() throws Exception {
+  void 비회원_댓글_등록_Redirect() throws Exception {
     // given
     Long postId = 1L;
 
@@ -47,9 +49,34 @@ class CommentControllerTest {
   }
 
   @Test
+  @DisplayName("비회원 상태로 댓글을 삭제할 수는 없습니다.")
+  void 비회원_댓글_삭제_Redirect() throws Exception {
+    Long commentId = 1L;
+
+    mockMvc.perform(delete("/comments/{commentId}", commentId)
+            .with(csrf()))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  @DisplayName("비회원 상태로 댓글을 수정할 수는 없습니다.")
+  void 비회원_댓글_수정_Redirect() throws Exception {
+    // given
+    Long postId = 1L;
+    Long commentId = 1L;
+
+    // when, then
+    mockMvc.perform(put("/posts/{postId}/comments/{commentId}", postId, commentId)
+            .with(csrf()))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
   @DisplayName("댓글 등록 시 내용을 비울 수 없습니다.")
   @WithMockCustomUser
-  void 게시글_등록_내용_유효성_검사() throws Exception {
+  void 댓글_등록_내용_유효성_검사() throws Exception {
     // given
     Long postId = 1L;
 
@@ -68,13 +95,23 @@ class CommentControllerTest {
   }
 
   @Test
-  @DisplayName("비회원 상태로 댓글을 삭제할 수는 없습니다.")
-  void 비회원_댓글_삭제_Redirect() throws Exception {
+  @DisplayName("댓글 수정 시 내용을 비울 수 없습니다.")
+  @WithMockCustomUser
+  void 댓글_수정_내용_유효성_검사() throws Exception {
+    // given
+    Long postId = 1L;
     Long commentId = 1L;
 
-    mockMvc.perform(delete("/comments/{commentId}", commentId)
-            .with(csrf()))
+    CommentUpdateRequest request = CommentUpdateRequest.builder()
+        .content("")
+        .build();
+
+    // when, then
+    mockMvc.perform(put("/posts/{postId}/comments/{commentId}", postId, commentId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(request)))
         .andDo(print())
-        .andExpect(status().is3xxRedirection());
+        .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/com/blog/tanylog/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/blog/tanylog/comment/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.blog.tanylog.comment.controller.dto.request.CommentSaveRequest;
+import com.blog.tanylog.comment.controller.dto.request.CommentUpdateRequest;
 import com.blog.tanylog.comment.domain.Comment;
 import com.blog.tanylog.comment.repository.CommentRepository;
 import com.blog.tanylog.config.DatabaseCleanup;
@@ -179,7 +180,7 @@ class CommentServiceTest {
   @WithMockCustomUser
   void 댓글_삭제시_대댓글_함께_삭제() {
     // given
-    Long postId = postRepository.findById(1L).get().getId();
+    Long postId = 1L;
     Long commentId = 1L;
 
     UserContext userContext = (UserContext) SecurityContextHolder.getContext()
@@ -204,7 +205,7 @@ class CommentServiceTest {
   @WithMockCustomUser
   void 대댓글_삭제() {
     // given
-    Long postId = postRepository.findById(1L).get().getId();
+    Long postId = 1L;
     Long commentId = 1L;
 
     UserContext userContext = (UserContext) SecurityContextHolder.getContext()
@@ -224,5 +225,28 @@ class CommentServiceTest {
     // then
     List<Comment> beforeDeleteComments = commentRepository.findAll();
     assertThat(beforeDeleteComments.get(comments.size() - 1).isDeleted()).isEqualTo(true);
+  }
+
+  @Test
+  @DisplayName("자신이 작성한 댓글을 수정할 수 있습니다.")
+  @WithMockCustomUser
+  void 댓글_수정() {
+    // given
+    UserContext userContext = (UserContext) SecurityContextHolder.getContext().getAuthentication()
+        .getPrincipal();
+
+    Long postId = 1L;
+    Long commentId = 1L;
+
+    CommentUpdateRequest request = CommentUpdateRequest.builder()
+        .content("update content")
+        .build();
+
+    // when
+    commentService.update(postId, commentId, userContext, request);
+
+    // then
+    Comment findComment = commentRepository.findById(1L).get();
+    assertThat(findComment.getContent()).isEqualTo("update content");
   }
 }


### PR DESCRIPTION
## Summary
- 댓글 관련 나머지 API 구현

## Description
- [x] 댓글, 대댓글 전체 조회 API 구현
  - 중복 코드가 많기 떄문에 Controller, Service Test 이후 리팩토링 예정
- [x] 댓글 수정 API 구현
