### PR TITLE
8월 16일 ~ 18일 간 작업 PR

### DIFF
--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -39,11 +39,16 @@ public class CommentController {
   }
 
   @PostMapping("/posts/{postId}/comments/{commentId}/reply")
-  public void saveReply(@PathVariable Long postId, @PathVariable Long commentId,
+  public ResponseEntity<Void> saveReply(@PathVariable Long postId, @PathVariable Long commentId,
       @AuthenticationPrincipal UserContext userContext,
       @Valid @RequestBody CommentSaveRequest request) {
 
-    commentService.saveReply(postId, commentId, userContext, request);
+    Long savedReplyCommentId = commentService.saveReply(postId, commentId, userContext, request);
+
+    URI location = URI.create(
+        "/posts/" + postId + "/comments/" + commentId + "/reply/" + savedReplyCommentId);
+
+    return ResponseEntity.created(location).build();
   }
 
   @DeleteMapping("/comments/{commentId}")

--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.blog.tanylog.comment.controller.dto.request.CommentUpdateRequest;
 import com.blog.tanylog.comment.controller.dto.response.CommentMultiReadResponse;
 import com.blog.tanylog.comment.service.CommentService;
 import com.blog.tanylog.config.security.UserContext;
+import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,10 +27,14 @@ public class CommentController {
   private final CommentService commentService;
 
   @PostMapping("/posts/{postId}/comments")
-  public void save(@PathVariable Long postId, @AuthenticationPrincipal UserContext userContext,
+  public ResponseEntity<Void> save(@PathVariable Long postId, @AuthenticationPrincipal UserContext userContext,
       @Valid @RequestBody CommentSaveRequest request) {
 
-    commentService.save(postId, userContext, request);
+    Long savedCommentId = commentService.save(postId, userContext, request);
+
+    URI location = URI.create("/posts/" + postId + "/comments/" + savedCommentId);
+
+    return ResponseEntity.created(location).build();
   }
 
   @PostMapping("/posts/{postId}/comments/{commentId}/reply")

--- a/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/tanylog/comment/controller/CommentController.java
@@ -27,7 +27,8 @@ public class CommentController {
   private final CommentService commentService;
 
   @PostMapping("/posts/{postId}/comments")
-  public ResponseEntity<Void> save(@PathVariable Long postId, @AuthenticationPrincipal UserContext userContext,
+  public ResponseEntity<Void> save(@PathVariable Long postId,
+      @AuthenticationPrincipal UserContext userContext,
       @Valid @RequestBody CommentSaveRequest request) {
 
     Long savedCommentId = commentService.save(postId, userContext, request);
@@ -52,12 +53,12 @@ public class CommentController {
     commentService.delete(commentId, userContext);
   }
 
-  @PutMapping("/posts/{postId}/comments/{commentId}")
-  public void update(@PathVariable Long postId, @PathVariable Long commentId,
+  @PutMapping("/comments/{commentId}")
+  public void update(@PathVariable Long commentId,
       @AuthenticationPrincipal UserContext userContext,
       @Valid @RequestBody CommentUpdateRequest request) {
 
-    commentService.update(postId, commentId, userContext, request);
+    commentService.update(commentId, userContext, request);
   }
 
   @GetMapping("/posts/{postId}/comments")

--- a/src/main/java/com/blog/tanylog/comment/domain/Comment.java
+++ b/src/main/java/com/blog/tanylog/comment/domain/Comment.java
@@ -58,9 +58,10 @@ public class Comment extends BaseEntity {
   private List<Comment> childComments = new ArrayList<>();
 
   @Builder
-  public Comment(String content, boolean isDeleted) {
+  public Comment(String content, boolean isDeleted, int replyDepth) {
     this.content = content;
     this.isDeleted = isDeleted;
+    this.replyDepth = replyDepth;
   }
 
   public boolean checkDepth() {

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentCustomRepository.java
@@ -8,5 +8,5 @@ public interface CommentCustomRepository {
 
   List<Comment> readNoOffset(Long postId, CommentPageSearch commentPageSearch);
 
-  List<Comment> readReplyNoOffset(Long postId, Long commentId, CommentPageSearch commentPageSearch);
+  List<Comment> readReplyNoOffset(Long postId, Long parentCommentId, CommentPageSearch commentPageSearch);
 }

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentRepositoryImpl.java
@@ -39,7 +39,7 @@ public class CommentRepositoryImpl implements CommentCustomRepository {
   }
 
   @Override
-  public List<Comment> readReplyNoOffset(Long postId, Long commentId, CommentPageSearch commentPageSearch) {
+  public List<Comment> readReplyNoOffset(Long postId, Long parentCommentId, CommentPageSearch commentPageSearch) {
     Long lastRecordId = commentPageSearch.getLastRecordId();
 
     BooleanBuilder dynamicLtId = new BooleanBuilder();
@@ -55,7 +55,7 @@ public class CommentRepositoryImpl implements CommentCustomRepository {
         .join(QComment.comment.post).fetchJoin()
         .where(dynamicLtId.and(QComment.comment.isDeleted.eq(false))
             .and(QComment.comment.post.id.eq(postId))
-            .and(QComment.comment.parentComment.id.eq(commentId))
+            .and(QComment.comment.parentComment.id.eq(parentCommentId))
             .and(QComment.comment.replyDepth.eq(1)))
         .orderBy(QComment.comment.id.desc())
         .limit(commentPageSearch.getSize())

--- a/src/main/java/com/blog/tanylog/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/blog/tanylog/comment/repository/CommentRepositoryImpl.java
@@ -58,7 +58,7 @@ public class CommentRepositoryImpl implements CommentCustomRepository {
             .and(QComment.comment.parentComment.id.eq(commentId))
             .and(QComment.comment.replyDepth.eq(1)))
         .orderBy(QComment.comment.id.desc())
-        .limit(5)
+        .limit(commentPageSearch.getSize())
         .fetch();
   }
 }

--- a/src/main/java/com/blog/tanylog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/tanylog/comment/service/CommentService.java
@@ -12,6 +12,7 @@ import com.blog.tanylog.config.security.UserContext;
 import com.blog.tanylog.global.exception.domain.CommentDepthOverException;
 import com.blog.tanylog.global.exception.domain.CommentNotFound;
 import com.blog.tanylog.global.exception.domain.OtherUserDeleteException;
+import com.blog.tanylog.global.exception.domain.OtherUserUpdateException;
 import com.blog.tanylog.global.exception.domain.PostNotFound;
 import com.blog.tanylog.global.exception.domain.UserNotFound;
 import com.blog.tanylog.post.domain.Post;
@@ -99,21 +100,18 @@ public class CommentService {
   }
 
   @Transactional
-  public void update(Long postId, Long commentId, UserContext userContext,
+  public void update(Long commentId, UserContext userContext,
       CommentUpdateRequest request) {
     Long userId = userContext.getSessionUser().getUserId();
     User loginUser = userRepository.findById(userId)
         .orElseThrow(UserNotFound::new);
 
-    Post findPost = postRepository.findById(postId)
-        .orElseThrow(PostNotFound::new);
-
-    if (!findPost.checkUser(loginUser)) {
-      throw new OtherUserDeleteException();
-    }
-
     Comment findComment = commentRepository.findById(commentId)
         .orElseThrow(CommentNotFound::new);
+
+    if (!findComment.checkUser(loginUser)) {
+      throw new OtherUserUpdateException();
+    }
 
     String updateContent = request.getContent();
 

--- a/src/main/java/com/blog/tanylog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/tanylog/comment/service/CommentService.java
@@ -120,8 +120,7 @@ public class CommentService {
 
   @Transactional
   public CommentMultiReadResponse readAll(Long postId, CommentPageSearch commentPageSearch) {
-    // user 필드를 쓰지 않는데 굳이 findByPostId() 대신 findById() 써도 될 듯?
-    Post findPost = postRepository.findByPostId(postId).orElseThrow(PostNotFound::new);
+    Post findPost = postRepository.findById(postId).orElseThrow(PostNotFound::new);
 
     List<Comment> comments = commentRepository.readNoOffset(findPost.getId(), commentPageSearch);
 
@@ -147,12 +146,12 @@ public class CommentService {
 
   public CommentMultiReadResponse readReplyAll(Long postId, Long commentId,
       CommentPageSearch commentPageSearch) {
-    Post findPost = postRepository.findByPostId(postId).orElseThrow(PostNotFound::new);
+    Post findPost = postRepository.findById(postId).orElseThrow(PostNotFound::new);
 
-    Comment findComment = commentRepository.findById(commentId).orElseThrow(CommentNotFound::new);
+    Comment parentComment = commentRepository.findById(commentId).orElseThrow(CommentNotFound::new);
 
     List<Comment> comments = commentRepository.readReplyNoOffset(findPost.getId(),
-        findComment.getId(), commentPageSearch);
+        parentComment.getId(), commentPageSearch);
 
     List<CommentSingleReadResponse> response = comments.stream()
         .map(comment -> CommentSingleReadResponse.builder()

--- a/src/main/java/com/blog/tanylog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/tanylog/comment/service/CommentService.java
@@ -33,7 +33,7 @@ public class CommentService {
   private final PostRepository postRepository;
 
   @Transactional
-  public void save(Long postId, UserContext userContext, CommentSaveRequest request) {
+  public Long save(Long postId, UserContext userContext, CommentSaveRequest request) {
     Long userId = userContext.getSessionUser().getUserId();
     User loginUser = userRepository.findById(userId)
         .orElseThrow(UserNotFound::new);
@@ -48,7 +48,9 @@ public class CommentService {
     comment.addUser(loginUser);
     comment.addPost(findPost);
 
-    commentRepository.save(comment);
+    Comment savedComment = commentRepository.save(comment);
+
+    return savedComment.getId();
   }
 
   @Transactional

--- a/src/main/java/com/blog/tanylog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/tanylog/comment/service/CommentService.java
@@ -56,7 +56,7 @@ public class CommentService {
   }
 
   @Transactional
-  public void saveReply(Long postId, Long commentId, UserContext userContext,
+  public Long saveReply(Long postId, Long commentId, UserContext userContext,
       CommentSaveRequest request) {
     Long userId = userContext.getSessionUser().getUserId();
     User loginUser = userRepository.findById(userId)
@@ -81,7 +81,9 @@ public class CommentService {
     replyComment.addPost(findPost);
     replyComment.addRelationByComment(parentComment);
 
-    commentRepository.save(replyComment);
+    Comment savedReplyComment = commentRepository.save(replyComment);
+
+    return savedReplyComment.getId();
   }
 
   @Transactional

--- a/src/main/java/com/blog/tanylog/global/exception/domain/CommentNotFound.java
+++ b/src/main/java/com/blog/tanylog/global/exception/domain/CommentNotFound.java
@@ -2,7 +2,7 @@ package com.blog.tanylog.global.exception.domain;
 
 public class CommentNotFound extends GlobalException {
 
-  private static final String MESSAGE = "존재하지 않는 게시글입니다.";
+  private static final String MESSAGE = "존재하지 않는 댓글 입니다.";
 
   public CommentNotFound() {
     super(MESSAGE);

--- a/src/main/java/com/blog/tanylog/global/exception/domain/OtherUserDeleteException.java
+++ b/src/main/java/com/blog/tanylog/global/exception/domain/OtherUserDeleteException.java
@@ -2,7 +2,7 @@ package com.blog.tanylog.global.exception.domain;
 
 public class OtherUserDeleteException extends GlobalException {
 
-  private static final String MESSAGE = "다른 유저의 게시글은 삭제할 수 없습니다.";
+  private static final String MESSAGE = "다른 유저의 글은 삭제할 수 없습니다.";
 
   public OtherUserDeleteException() {
     super(MESSAGE);

--- a/src/main/java/com/blog/tanylog/global/exception/domain/OtherUserUpdateException.java
+++ b/src/main/java/com/blog/tanylog/global/exception/domain/OtherUserUpdateException.java
@@ -2,7 +2,7 @@ package com.blog.tanylog.global.exception.domain;
 
 public class OtherUserUpdateException extends GlobalException {
 
-  private static final String MESSAGE = "다른 유저의 게시글은 수정할 수 없습니다.";
+  private static final String MESSAGE = "다른 유저의 글은 수정할 수 없습니다.";
 
   public OtherUserUpdateException() {
     super(MESSAGE);

--- a/src/main/java/com/blog/tanylog/post/controller/PostController.java
+++ b/src/main/java/com/blog/tanylog/post/controller/PostController.java
@@ -7,6 +7,7 @@ import com.blog.tanylog.post.controller.dto.request.PostUpdateRequest;
 import com.blog.tanylog.post.controller.dto.response.PostMultiReadResponse;
 import com.blog.tanylog.post.controller.dto.response.PostSingleReadResponse;
 import com.blog.tanylog.post.service.PostService;
+import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +28,13 @@ public class PostController {
   private final PostService postService;
 
   @PostMapping("/posts")
-  public void save(@Valid @RequestBody PostSaveRequest request,
+  public ResponseEntity<Void> save(@Valid @RequestBody PostSaveRequest request,
       @AuthenticationPrincipal UserContext userContext) {
-    postService.save(userContext, request);
+    Long savedPostId = postService.save(userContext, request);
+
+    URI location = URI.create("/posts/" + savedPostId);
+
+    return ResponseEntity.created(location).build();
   }
 
   @DeleteMapping("/posts/{postId}")

--- a/src/main/java/com/blog/tanylog/post/controller/PostController.java
+++ b/src/main/java/com/blog/tanylog/post/controller/PostController.java
@@ -50,8 +50,9 @@ public class PostController {
   }
 
   @GetMapping("/posts/{postId}")
-  public ResponseEntity<PostSingleReadResponse> read(@PathVariable Long postId) {
-    PostSingleReadResponse response = postService.read(postId);
+  public ResponseEntity<PostSingleReadResponse> read(@PathVariable Long postId,
+      @AuthenticationPrincipal UserContext userContext) {
+    PostSingleReadResponse response = postService.read(postId, userContext);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/blog/tanylog/post/controller/dto/response/PostSingleReadResponse.java
+++ b/src/main/java/com/blog/tanylog/post/controller/dto/response/PostSingleReadResponse.java
@@ -10,16 +10,18 @@ public class PostSingleReadResponse {
   private final Long id;
   private final String title;
   private final String content;
+  private final boolean isLiked;
   private final LocalDateTime createdDate;
   private final LocalDateTime modifiedDate;
   private final PostWriterResponse writer;
 
   @Builder
-  public PostSingleReadResponse(Long id, String title, String content,
+  public PostSingleReadResponse(Long id, String title, String content, boolean isLiked,
       LocalDateTime createdDate, LocalDateTime modifiedDate, PostWriterResponse writer) {
     this.id = id;
     this.title = title;
     this.content = content;
+    this.isLiked = isLiked;
     this.createdDate = createdDate;
     this.modifiedDate = modifiedDate;
     this.writer = writer;

--- a/src/main/java/com/blog/tanylog/post/repository/PostRepository.java
+++ b/src/main/java/com/blog/tanylog/post/repository/PostRepository.java
@@ -7,6 +7,10 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 
+  /**
+   * Description
+   *  게시글 ID 를 통해 해당 게시글을 조회하면서 어떤 유저가 작성 했는지 함께 조회합니다.
+   */
   @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.id = :postId")
   Optional<Post> findByPostId(Long postId);
 }

--- a/src/main/java/com/blog/tanylog/post/service/PostService.java
+++ b/src/main/java/com/blog/tanylog/post/service/PostService.java
@@ -81,7 +81,11 @@ public class PostService {
     findPost.updatePost(updateTitle, updateContent);
   }
 
-  // GET Method 에 Transactional 을 꼭 사용해야할까 ?
+  /**
+   * GET Method 에 Transactional 을 꼭 사용해야할까 ?
+   *  선언적 트랜잭션이 없더라도 단순 조회는 가능하나, 영속성 컨텍스트가 생성되지 않아 관리를 받지 못하기 때문에 Lazy Loading 관련 예외가 발생할 수 있다.
+   *  물론 findPostId() 는 FETCH JOIN 을 사용하고 있기 때문에 한번에 User 데이터까지 조회하기 때문에 Lazy Loading 예외는 발생하지 않는다.
+   */
   @Transactional
   public PostSingleReadResponse read(Long postId) {
     Post findPost = postRepository.findByPostId(postId)

--- a/src/main/java/com/blog/tanylog/post/service/PostService.java
+++ b/src/main/java/com/blog/tanylog/post/service/PostService.java
@@ -29,7 +29,7 @@ public class PostService {
   private final UserRepository userRepository;
 
   @Transactional
-  public void save(UserContext userContext, PostSaveRequest request) {
+  public Long save(UserContext userContext, PostSaveRequest request) {
     Long userId = userContext.getSessionUser().getUserId();
     User loginUser = userRepository.findById(userId)
         .orElseThrow(UserNotFound::new);
@@ -41,7 +41,9 @@ public class PostService {
     Post post = request.toEntity(title, content, isDeleted);
     post.addUser(loginUser);
 
-    postRepository.save(post);
+    Post savedPost = postRepository.save(post);
+
+    return savedPost.getId();
   }
 
   @Transactional

--- a/src/main/java/com/blog/tanylog/post/service/PostService.java
+++ b/src/main/java/com/blog/tanylog/post/service/PostService.java
@@ -13,6 +13,7 @@ import com.blog.tanylog.post.controller.dto.response.PostSingleReadResponse;
 import com.blog.tanylog.post.controller.dto.response.PostWriterResponse;
 import com.blog.tanylog.post.domain.Post;
 import com.blog.tanylog.post.repository.PostRepository;
+import com.blog.tanylog.postLike.repository.PostLikeRepository;
 import com.blog.tanylog.user.domain.User;
 import com.blog.tanylog.user.repository.UserRepository;
 import java.util.List;
@@ -27,6 +28,7 @@ public class PostService {
 
   private final PostRepository postRepository;
   private final UserRepository userRepository;
+  private final PostLikeRepository postLikeRepository;
 
   @Transactional
   public Long save(UserContext userContext, PostSaveRequest request) {
@@ -82,17 +84,27 @@ public class PostService {
   }
 
   /**
-   * GET Method 에 Transactional 을 꼭 사용해야할까 ?
-   *  선언적 트랜잭션이 없더라도 단순 조회는 가능하나, 영속성 컨텍스트가 생성되지 않아 관리를 받지 못하기 때문에 Lazy Loading 관련 예외가 발생할 수 있다.
-   *  물론 findPostId() 는 FETCH JOIN 을 사용하고 있기 때문에 한번에 User 데이터까지 조회하기 때문에 Lazy Loading 예외는 발생하지 않는다.
+   * GET Method 에 Transactional 을 꼭 사용해야할까 ? 선언적 트랜잭션이 없더라도 단순 조회는 가능하나, 영속성 컨텍스트가 생성되지 않아 관리를 받지
+   * 못하기 때문에 Lazy Loading 관련 예외가 발생할 수 있다. 물론 findPostId() 는 FETCH JOIN 을 사용하고 있기 때문에 한번에 User 데이터까지
+   * 조회하기 때문에 Lazy Loading 예외는 발생하지 않는다.
    */
-  @Transactional
-  public PostSingleReadResponse read(Long postId) {
+  /**
+   * 로그인 상태에서 조회라면 해당 유저가 post ID 게시글을 좋아요 했는지 안했는지에 대한 판단이 필요합니다. 좋아요 객체가 존재한다면 이미 좋아요 한 상태, 존재하지
+   * 않다면 좋아요를 하지 않은 상태입니다. 비로그인 상태에서 조회라면 isLiked = false 로 응답합니다.
+   */
+  @Transactional(readOnly = true)
+  public PostSingleReadResponse read(Long postId, UserContext userContext) {
+    boolean isLiked = false;
+
+    if (userContext != null) {
+      isLiked = postLikeRepository.findPostLikeByPostIdAndUserId(postId,
+          userContext.getSessionUser().getUserId()).isPresent();
+    }
+
     Post findPost = postRepository.findByPostId(postId)
         .orElseThrow(PostNotFound::new);
 
     User user = findPost.getUser();
-
     PostWriterResponse writer = PostWriterResponse.builder()
         .name(user.getName())
         .email(user.getEmail())
@@ -103,13 +115,14 @@ public class PostService {
         .id(findPost.getId())
         .title(findPost.getTitle())
         .content(findPost.getContent())
+        .isLiked(isLiked)
         .createdDate(findPost.getCreateAt())
         .modifiedDate(findPost.getModifiedAt())
         .writer(writer)
         .build();
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public PostMultiReadResponse readAll(PageSearch pageSearch) {
     List<Post> offset = postRepository.readAll(pageSearch);
 

--- a/src/main/java/com/blog/tanylog/postLike/controller/PostLikeController.java
+++ b/src/main/java/com/blog/tanylog/postLike/controller/PostLikeController.java
@@ -1,0 +1,26 @@
+package com.blog.tanylog.postLike.controller;
+
+import com.blog.tanylog.config.security.UserContext;
+import com.blog.tanylog.postLike.controller.dto.request.PostLikeSaveRequest;
+import com.blog.tanylog.postLike.service.PostLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PostLikeController {
+
+  private final PostLikeService postLikeService;
+
+  @PostMapping("/posts/{postId}/like")
+  public void save(@PathVariable Long postId,
+      @AuthenticationPrincipal UserContext userContext,
+      @RequestBody PostLikeSaveRequest request) {
+
+    postLikeService.save(postId, userContext, request);
+  }
+}

--- a/src/main/java/com/blog/tanylog/postLike/controller/dto/request/PostLikeSaveRequest.java
+++ b/src/main/java/com/blog/tanylog/postLike/controller/dto/request/PostLikeSaveRequest.java
@@ -1,0 +1,27 @@
+package com.blog.tanylog.postLike.controller.dto.request;
+
+import com.blog.tanylog.postLike.domain.PostLike;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLikeSaveRequest {
+
+  @JsonProperty("isLiked")
+  private boolean isLiked;
+
+  // postLiked != null && isLiked == true 의미 : 이미 좋아요 한 상태임 (삭제만 가능한 상황)
+  // postLiked == null && isLiked == false 의미 : 좋아요 안한 상태임 (추가만 가능한 상황)
+  public void validate(PostLike postLike) {
+    if (postLike != null && !this.isLiked) {
+      throw new IllegalArgumentException("잘못되 isLiked 요청입니다.");
+    }
+
+    if (postLike == null && this.isLiked) {
+      throw new IllegalArgumentException("잘못된 isLiked 요청입니다.");
+    }
+  }
+}

--- a/src/main/java/com/blog/tanylog/postLike/domain/PostLike.java
+++ b/src/main/java/com/blog/tanylog/postLike/domain/PostLike.java
@@ -22,8 +22,6 @@ public class PostLike {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private boolean isLiked;
-
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "post_id")
   private Post post;
@@ -31,4 +29,16 @@ public class PostLike {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;
+
+  public void addUser(User user) {
+    this.user = user;
+  }
+
+  public void addPost(Post post) {
+    this.post = post;
+  }
+
+  public static PostLike createPostLike() {
+    return new PostLike();
+  }
 }

--- a/src/main/java/com/blog/tanylog/postLike/repository/PostLikeRepository.java
+++ b/src/main/java/com/blog/tanylog/postLike/repository/PostLikeRepository.java
@@ -1,0 +1,18 @@
+package com.blog.tanylog.postLike.repository;
+
+import com.blog.tanylog.postLike.domain.PostLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+  /**
+   * 좋아요 객체의 존재 여부만 판단할 때 사용하기 때문에 User, Post 와의 FETCH JOIN 은 사용하지 않습니다.
+   */
+  @Query("SELECT pl FROM PostLike pl WHERE pl.post.id = :postId AND pl.user.id = :userId")
+  Optional<PostLike> findPostLikeByPostIdAndUserId(
+      @Param("postId") Long postId,
+      @Param("userId") Long userId);
+}

--- a/src/main/java/com/blog/tanylog/postLike/service/PostLikeService.java
+++ b/src/main/java/com/blog/tanylog/postLike/service/PostLikeService.java
@@ -1,0 +1,51 @@
+package com.blog.tanylog.postLike.service;
+
+import com.blog.tanylog.config.security.UserContext;
+import com.blog.tanylog.global.exception.domain.PostNotFound;
+import com.blog.tanylog.global.exception.domain.UserNotFound;
+import com.blog.tanylog.post.domain.Post;
+import com.blog.tanylog.post.repository.PostRepository;
+import com.blog.tanylog.postLike.controller.dto.request.PostLikeSaveRequest;
+import com.blog.tanylog.postLike.domain.PostLike;
+import com.blog.tanylog.postLike.repository.PostLikeRepository;
+import com.blog.tanylog.user.domain.User;
+import com.blog.tanylog.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PostLikeService {
+
+  private final PostLikeRepository postLikeRepository;
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void save(Long postId, UserContext userContext, PostLikeSaveRequest request) {
+    Long userId = userContext.getSessionUser().getUserId();
+    User loginUser = userRepository.findById(userId)
+        .orElseThrow(UserNotFound::new);
+
+    Post findPost = postRepository.findById(postId)
+        .orElseThrow(PostNotFound::new);
+
+    // 클라이언트에서 실수할수도 있으니 이중 검증
+    request.validate(postLikeRepository.findPostLikeByPostIdAndUserId(postId, userId)
+        .orElse(null));
+
+    if (request.isLiked()) {
+      Optional<PostLike> findPostLike = postLikeRepository.findPostLikeByPostIdAndUserId(postId, userId);
+      findPostLike.ifPresent(postLikeRepository::delete);
+
+    } else {
+      PostLike postLike = PostLike.createPostLike();
+      postLike.addUser(loginUser);
+      postLike.addPost(findPost);
+
+      postLikeRepository.save(postLike);
+    }
+  }
+}

--- a/src/test/java/com/blog/tanylog/post/service/PostServiceTest.java
+++ b/src/test/java/com/blog/tanylog/post/service/PostServiceTest.java
@@ -97,7 +97,7 @@ class PostServiceTest {
     Long postId = 1L;
 
     // when
-    PostSingleReadResponse response = postService.read(postId);
+    PostSingleReadResponse response = postService.read(postId, null);
 
     // then
     assertThat(response).isNotNull();

--- a/src/test/java/com/blog/tanylog/post/service/PostServiceTest.java
+++ b/src/test/java/com/blog/tanylog/post/service/PostServiceTest.java
@@ -51,16 +51,6 @@ class PostServiceTest {
         .build();
 
     userRepository.save(user);
-
-    Post post = Post.builder()
-        .title("dummy_title")
-        .content("dummy_content")
-        .isDeleted(false)
-        .build();
-
-    post.addUser(user);
-
-    postRepository.save(post);
   }
 
   @AfterEach
@@ -87,13 +77,23 @@ class PostServiceTest {
 
     // then
     List<Post> findPosts = postRepository.findAll();
-    assertThat(findPosts.size()).isEqualTo(2);
+    assertThat(findPosts.size()).isEqualTo(1);
   }
 
   @Test
   @DisplayName("권한에 상관없이 게시글을 조회할 수 있습니다.")
   void 게시글_단일_조회() {
     // given
+    User user = userRepository.findById(1L).get();
+    Post post = Post.builder()
+        .title("test title")
+        .content("test content")
+        .isDeleted(false)
+        .build();
+
+    post.addUser(user);
+    postRepository.save(post);
+
     Long postId = 1L;
 
     // when
@@ -101,7 +101,7 @@ class PostServiceTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("dummy_title");
+    assertThat(response.getTitle()).isEqualTo("test title");
   }
 
   @Test
@@ -109,6 +109,16 @@ class PostServiceTest {
   @WithMockCustomUser
   void 게시글_삭제() {
     // given
+    User user = userRepository.findById(1L).get();
+    Post post = Post.builder()
+        .title("test title")
+        .content("test content")
+        .isDeleted(false)
+        .build();
+
+    post.addUser(user);
+    postRepository.save(post);
+
     Long postId = 1L;
 
     UserContext userContext = (UserContext) SecurityContextHolder.getContext()
@@ -127,6 +137,16 @@ class PostServiceTest {
   @WithMockCustomUser
   void 게시글_수정() {
     // given
+    User user = userRepository.findById(1L).get();
+    Post post = Post.builder()
+        .title("test title")
+        .content("test content")
+        .isDeleted(false)
+        .build();
+
+    post.addUser(user);
+    postRepository.save(post);
+
     Long postId = 1L;
 
     UserContext userContext = (UserContext) SecurityContextHolder.getContext()
@@ -151,6 +171,16 @@ class PostServiceTest {
   @WithMockCustomUser(userId = 2)
   void 타인_게시글_삭제() {
     // given
+    User user = userRepository.findById(1L).get();
+    Post post = Post.builder()
+        .title("test title")
+        .content("test content")
+        .isDeleted(false)
+        .build();
+
+    post.addUser(user);
+    postRepository.save(post);
+
     UserContext userContext = (UserContext) SecurityContextHolder.getContext().getAuthentication()
         .getPrincipal();
 
@@ -175,6 +205,16 @@ class PostServiceTest {
   @WithMockCustomUser(userId = 2)
   void 타인_게시글_수정() {
     // given
+    User user = userRepository.findById(1L).get();
+    Post post = Post.builder()
+        .title("test title")
+        .content("test content")
+        .isDeleted(false)
+        .build();
+
+    post.addUser(user);
+    postRepository.save(post);
+
     UserContext userContext = (UserContext) SecurityContextHolder.getContext().getAuthentication()
         .getPrincipal();
 


### PR DESCRIPTION
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Fri Aug 18 15:09:21 2023 +0900

    ## 게시글 좋아요 API 구현

    ### Description
    - 현재 로그인한 유저, 좋아요 대상 게시물, 클라이언트에서 보내는 true, false 를 통해 게시글 좋아요 또는 삭제할 수 있도록 구현
    - Reqeust DTO 에서 클라이언트에서 isLiked 필드 유효성 검사 실시 (클라이언트 실수 방지)
    - 이미 게시글을 좋아요 한 상태라면 취소, 좋아요 하지 않은 상태라면 좋아요 등록될 수 있도록 구현
commit d26b132e5417c8eedf4e3262ad297977d756338c
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Aug 17 19:28:02 2023 +0900

    ## 게시글 단건 조회 API 수정

    ### Description
    - 로그인 상태, 비로그인 상태를 구분하기 위해 UserContext 를 매개변수로 받도록 수정
    - 로그인 상태라면 해당 게시글을 좋아요 했는지 안했는지 클라이언트로 응답하기 위해 로직 수정하고 Response DTO 에 isLiked 필드 변수 추가
    - 게시글 단건 조회 API 테스트 수정

commit c9d9abe39bd9e91f5f1255610dd1c40f28ce428f
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Aug 17 15:43:08 2023 +0900

    ## 주석 추가

    ### Description
    - 주석 추가

commit 247086a3daa5e57e6f263f1f8fef4c2920950a8f
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 18:11:20 2023 +0900

    ## 대댓글 등록 API 응답 Status 수정

    ### Description
    - 200 OK 에서 201 Created 응답으로 변경

commit a7e4c3c577381c98a6353b4b092af339182174e7
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 17:44:01 2023 +0900

    ## 댓글 Service 코드 리팩토링

    ### Description
    - 댓글, 대댓글 전체 조회 로직 시 Comment 객체를 Response DTO 로 변환하는 중복 로직을 commentToSingleResponse() 메서드로 추출해 사용하도록 변경

    - commentId 값이 있는지 없는지에 따라 댓글 전체 조회인지, 대댓글 전체 조회인지 판단해 알맞는 List<Comment> 타입 값을 반환하는 로직을 getComments() 메서드로 추출해 사용하도록 변경

commit 0b457495e01145846ee281fff4965779c1d36893
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 17:09:14 2023 +0900

    ## 댓글, 대댓글 조회 Service 코드 수정

    ### Description
    - 게시글 정보를 가져올 때 유저 정보는 사용하지 않기 떄문에 불필요한 리소스 낭비를 방지하기 위해 findByPostId() 대신 findById() 사용하도록 변경
    - 대댓글 조회 로직 시 부모 댓글 객체를 가져올 때 findComment 대신 가독성을 위해 parentId 로 변수 네이밍 변경

commit 5c27a73cceaf62325d7e2f6531c2e50d0ad0fbba
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 16:53:57 2023 +0900

    ## OtherUser ~ Exception 메세지 수정

    ### Description
    - 게시글에서 글로 변경

commit ef05897e6d4c972b9440615864ee7392e23bd87c
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 16:53:25 2023 +0900

    ## 댓글 삭제 API Service 실패 테스트 작성 및 댓글 수정 API 로직 수정

    ### Description
    - 다른 사람이 작성한 댓글을 삭제할 수 없는지 확인하는 실패 테스트 작성
    - 댓글 수정 API 로직 수정으로 인한 댓글 수정 API Service 테스트 로직 일부 수정

commit e44bcaacfe8f6160dda36217dbd15651542837b0
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 16:51:41 2023 +0900

    ## 댓글 수정 API 로직 수정

    ### Description
    - 댓글 수정 시 게시글 아이디는 필요없으므로 삭제
    - PathVariable Long postId 삭제로 Contoroller, Service 코드 일부 수정

commit 04f9678533b323cfacff0a36738333c63c65c335
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 16:32:34 2023 +0900

    ## 게시글 API Service 테스트 코드 수정

    ### Description
    - @BeforeEach 에서 실시하던 더미 게시글 데이터 저장을 각 테스트 코드에서 하도록 변경 (헷갈려서..)

commit 9235ba59cccee642cfabd65cf81df1cc7740078f
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 16:24:18 2023 +0900

    ## 댓글 등록 API 응답 Status 수정

    ### Description
    - 응답 Status 를 200 OK 에서 201 Created 로 수정

commit 8e41d6b6f94be89b4cdcde7b58117fbb4fa503da
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 16:19:32 2023 +0900

    ## 게시글 등록 API 응답 Status 수정

    ### Description
    - 응답 Status 를 200 OK 에서 201 Created 로 수정

commit 1bd23271d7ec470e8dcb7050151bbd014cb118d8
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 15:54:32 2023 +0900

    ## 댓글, 대댓글 조회 Service 테스트 작성


commit d4128d8255fc91fcd27b3c418030b15dfc64ccf9
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Wed Aug 16 15:53:40 2023 +0900

    ## Comment 관련 자잘한 수정

    ### Description
    - Comment Builder 로직 수정
    - Querydsl 쿼리문 수정
    - Exception 메세지 수정
