### PR TITLE
게시글 좋아요 API 수정 및 검색 기능 추가

### DIFF
--- a/src/main/java/com/blog/tanylog/global/exception/controller/ExceptionController.java
+++ b/src/main/java/com/blog/tanylog/global/exception/controller/ExceptionController.java
@@ -2,6 +2,8 @@ package com.blog.tanylog.global.exception.controller;
 
 import com.blog.tanylog.global.exception.controller.dto.ExceptionResponse;
 import com.blog.tanylog.global.exception.domain.GlobalException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import org.hibernate.StaleStateException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -39,5 +41,27 @@ public class ExceptionController {
     }
 
     return response;
+  }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  @ExceptionHandler(SQLIntegrityConstraintViolationException.class)
+  public ResponseEntity<ExceptionResponse> uniqueSaveValid() {
+    ExceptionResponse response = ExceptionResponse.builder()
+        .code(500)
+        .message("중복된 좋아요 등록 요청입니다.")
+        .build();
+
+    return ResponseEntity.status(500).body(response);
+  }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  @ExceptionHandler(StaleStateException.class)
+  public ResponseEntity<ExceptionResponse> uniqueDeleteValid() {
+    ExceptionResponse response = ExceptionResponse.builder()
+        .code(500)
+        .message("중복된 좋아요 삭제 요청입니다.")
+        .build();
+
+    return ResponseEntity.status(500).body(response);
   }
 }

--- a/src/main/java/com/blog/tanylog/global/exception/domain/BadLikeException.java
+++ b/src/main/java/com/blog/tanylog/global/exception/domain/BadLikeException.java
@@ -1,0 +1,16 @@
+package com.blog.tanylog.global.exception.domain;
+
+public class BadLikeException extends GlobalException {
+
+  private static final String MESSAGE = "잘못된 isLiked 요청입니다.";
+
+  public BadLikeException() {
+    super(MESSAGE);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return 400;
+  }
+
+}

--- a/src/main/java/com/blog/tanylog/post/controller/dto/request/PageSearch.java
+++ b/src/main/java/com/blog/tanylog/post/controller/dto/request/PageSearch.java
@@ -10,11 +10,15 @@ public class PageSearch {
   private final Long lastRecordId;
   private final Integer page;
   private final Integer size;
+  private final String searchType;
+  private final String keyword;
 
-  public PageSearch(Long lastRecordId, Integer page, Integer size) {
+  public PageSearch(Long lastRecordId, Integer page, Integer size, String searchType, String keyword) {
     this.lastRecordId = (lastRecordId != null) ? lastRecordId : 1L;
     this.page = (page != null) ? page : 1;
     this.size = (size != null) ? size : 20;
+    this.searchType = (searchType != null) ? searchType : "";
+    this.keyword = (keyword != null) ? keyword : "";
   }
 
   // page 가 0인 경우 최소한 1을 반환하기 위함

--- a/src/main/java/com/blog/tanylog/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/blog/tanylog/post/repository/PostRepositoryImpl.java
@@ -4,9 +4,12 @@ import com.blog.tanylog.post.controller.dto.request.PageSearch;
 import com.blog.tanylog.post.domain.Post;
 import com.blog.tanylog.post.domain.QPost;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 public class PostRepositoryImpl implements PostCustomRepository {
@@ -15,14 +18,63 @@ public class PostRepositoryImpl implements PostCustomRepository {
 
   @Override
   public List<Post> readAll(PageSearch pageSearch) {
-    return jpaQueryFactory.selectFrom(QPost.post)
+    String searchType = pageSearch.getSearchType();
+    String keyword = pageSearch.getKeyword();
+    BooleanExpression searchPredicate = createSearchPredicate(searchType, keyword);
+
+    /**
+     * 정확한 Paging 을 위해 검색 쿼리와 페이징 쿼리 분리
+     */
+    JPAQuery<Post> searchQuery = jpaQueryFactory.selectFrom(QPost.post)
         .join(QPost.post.user)
         .fetchJoin()
-        .where(QPost.post.isDeleted.eq(false))
+        .where(QPost.post.isDeleted.eq(false), searchPredicate);
+
+    return searchQuery
         .limit(pageSearch.getSize())
         .offset(pageSearch.getOffset())
         .orderBy(QPost.post.id.desc())
         .fetch();
+  }
+
+  private BooleanExpression createSearchPredicate(String searchType, String keyword) {
+    BooleanExpression predicate = null;
+
+    if ("TITLE".equalsIgnoreCase(searchType)) {
+      predicate = createTitlePredicate(keyword);
+
+    } else if ("CONTENT".equalsIgnoreCase(searchType)) {
+      predicate = createContentPredicate(keyword);
+
+    } else if ("USER".equalsIgnoreCase(searchType)) {
+      predicate = createUserPredicate(keyword);
+    }
+
+    return predicate;
+  }
+
+  private BooleanExpression createUserPredicate(String keyword) {
+    if (!StringUtils.hasText(keyword)) {
+      return null;
+    }
+
+    return QPost.post.user.name.eq(keyword);
+  }
+
+  private BooleanExpression createTitlePredicate(String keyword) {
+    if (!StringUtils.hasText(keyword)) {
+      return null;
+    }
+
+    return QPost.post.title.containsIgnoreCase(keyword);
+  }
+
+  private BooleanExpression createContentPredicate(String keyword) {
+    if (!StringUtils.hasText(keyword)) {
+      return null;
+    }
+
+    return QPost.post.content.containsIgnoreCase(keyword);
   }
 
   @Override

--- a/src/main/java/com/blog/tanylog/postLike/controller/PostLikeController.java
+++ b/src/main/java/com/blog/tanylog/postLike/controller/PostLikeController.java
@@ -1,7 +1,7 @@
 package com.blog.tanylog.postLike.controller;
 
 import com.blog.tanylog.config.security.UserContext;
-import com.blog.tanylog.postLike.controller.dto.request.PostLikeSaveRequest;
+import com.blog.tanylog.postLike.controller.dto.request.PostLikeRequest;
 import com.blog.tanylog.postLike.service.PostLikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,8 +19,8 @@ public class PostLikeController {
   @PostMapping("/posts/{postId}/like")
   public void save(@PathVariable Long postId,
       @AuthenticationPrincipal UserContext userContext,
-      @RequestBody PostLikeSaveRequest request) {
+      @RequestBody PostLikeRequest request) {
 
-    postLikeService.save(postId, userContext, request);
+    postLikeService.saveOrDelete(postId, userContext, request);
   }
 }

--- a/src/main/java/com/blog/tanylog/postLike/controller/dto/request/PostLikeRequest.java
+++ b/src/main/java/com/blog/tanylog/postLike/controller/dto/request/PostLikeRequest.java
@@ -1,27 +1,34 @@
 package com.blog.tanylog.postLike.controller.dto.request;
 
+import com.blog.tanylog.global.exception.domain.BadLikeException;
 import com.blog.tanylog.postLike.domain.PostLike;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostLikeSaveRequest {
+public class PostLikeRequest {
 
   @JsonProperty("isLiked")
   private boolean isLiked;
+
+  @Builder
+  public PostLikeRequest(boolean isLiked) {
+    this.isLiked = isLiked;
+  }
 
   // postLiked != null && isLiked == true 의미 : 이미 좋아요 한 상태임 (삭제만 가능한 상황)
   // postLiked == null && isLiked == false 의미 : 좋아요 안한 상태임 (추가만 가능한 상황)
   public void validate(PostLike postLike) {
     if (postLike != null && !this.isLiked) {
-      throw new IllegalArgumentException("잘못되 isLiked 요청입니다.");
+      throw new BadLikeException();
     }
 
     if (postLike == null && this.isLiked) {
-      throw new IllegalArgumentException("잘못된 isLiked 요청입니다.");
+      throw new BadLikeException();
     }
   }
 }

--- a/src/main/java/com/blog/tanylog/postLike/domain/PostLike.java
+++ b/src/main/java/com/blog/tanylog/postLike/domain/PostLike.java
@@ -9,6 +9,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +18,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post_like", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"post_id", "user_id"})})
 public class PostLike {
 
   @Id

--- a/src/main/java/com/blog/tanylog/postLike/service/PostLikeService.java
+++ b/src/main/java/com/blog/tanylog/postLike/service/PostLikeService.java
@@ -5,7 +5,7 @@ import com.blog.tanylog.global.exception.domain.PostNotFound;
 import com.blog.tanylog.global.exception.domain.UserNotFound;
 import com.blog.tanylog.post.domain.Post;
 import com.blog.tanylog.post.repository.PostRepository;
-import com.blog.tanylog.postLike.controller.dto.request.PostLikeSaveRequest;
+import com.blog.tanylog.postLike.controller.dto.request.PostLikeRequest;
 import com.blog.tanylog.postLike.domain.PostLike;
 import com.blog.tanylog.postLike.repository.PostLikeRepository;
 import com.blog.tanylog.user.domain.User;
@@ -24,20 +24,22 @@ public class PostLikeService {
   private final UserRepository userRepository;
 
   @Transactional
-  public void save(Long postId, UserContext userContext, PostLikeSaveRequest request) {
+  public void saveOrDelete(Long postId, UserContext userContext, PostLikeRequest request) {
     Long userId = userContext.getSessionUser().getUserId();
+
+    Optional<PostLike> findPostLike = postLikeRepository.findPostLikeByPostIdAndUserId(
+        postId, userId);
+
+    // 클라이언트에서 실수할수도 있으니 이중 검증
+    request.validate(findPostLike.orElse(null));
+
     User loginUser = userRepository.findById(userId)
         .orElseThrow(UserNotFound::new);
 
     Post findPost = postRepository.findById(postId)
         .orElseThrow(PostNotFound::new);
 
-    // 클라이언트에서 실수할수도 있으니 이중 검증
-    request.validate(postLikeRepository.findPostLikeByPostIdAndUserId(postId, userId)
-        .orElse(null));
-
     if (request.isLiked()) {
-      Optional<PostLike> findPostLike = postLikeRepository.findPostLikeByPostIdAndUserId(postId, userId);
       findPostLike.ifPresent(postLikeRepository::delete);
 
     } else {

--- a/src/test/java/com/blog/tanylog/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/blog/tanylog/comment/controller/CommentControllerTest.java
@@ -99,7 +99,6 @@ class CommentControllerTest {
   @WithMockCustomUser
   void 댓글_수정_내용_유효성_검사() throws Exception {
     // given
-    Long postId = 1L;
     Long commentId = 1L;
 
     CommentUpdateRequest request = CommentUpdateRequest.builder()
@@ -107,7 +106,7 @@ class CommentControllerTest {
         .build();
 
     // when, then
-    mockMvc.perform(put("/posts/{postId}/comments/{commentId}", postId, commentId)
+    mockMvc.perform(put("/comments/{commentId}", commentId)
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(mapper.writeValueAsString(request)))

--- a/src/test/java/com/blog/tanylog/postLike/controller/PostLikeControllerTest.java
+++ b/src/test/java/com/blog/tanylog/postLike/controller/PostLikeControllerTest.java
@@ -1,0 +1,45 @@
+package com.blog.tanylog.postLike.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.blog.tanylog.config.TestSecurityConfig;
+import com.blog.tanylog.post.controller.PostController;
+import com.blog.tanylog.post.service.PostService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PostController.class)
+@Import({TestSecurityConfig.class})
+class PostLikeControllerTest {
+
+  @Autowired
+  private ObjectMapper mapper;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private PostService postService;
+
+  @Test
+  @DisplayName("비회원 상태로 게시글 좋아요를 하거나 취소할 수 없습니다.")
+  void 비회원_게시글_좋아요_등록_Redirect() throws Exception {
+    // given
+    Long postId = 1L;
+
+    // when, then
+    mockMvc.perform(post("/posts/{postId}/like", postId)
+            .with(csrf()))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection());
+  }
+}

--- a/src/test/java/com/blog/tanylog/postLike/controller/dto/request/PostLikeRequestTest.java
+++ b/src/test/java/com/blog/tanylog/postLike/controller/dto/request/PostLikeRequestTest.java
@@ -1,0 +1,39 @@
+package com.blog.tanylog.postLike.controller.dto.request;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.blog.tanylog.global.exception.domain.BadLikeException;
+import com.blog.tanylog.postLike.domain.PostLike;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostLikeRequestTest {
+
+  @Test
+  @DisplayName("게시글 좋아요 객체가 있는 상태에서 좋아요 등록 요청이 오면 실패합니다.")
+  void 게시글_좋아요_등록_검증() {
+    // given
+    PostLike postLike = PostLike.createPostLike();
+
+    PostLikeRequest request = PostLikeRequest.builder()
+        .isLiked(false)
+        .build();
+
+    // when, then
+    assertThrows(BadLikeException.class, () -> request.validate(postLike));
+  }
+
+  @Test
+  @DisplayName("게시글 좋아요 객체가 없는 상태에서 좋아요 삭제 요청이 오면 실패합니다.")
+  void 게시글_좋야요_삭제_검증() {
+    // given
+    PostLike postLike = null;
+
+    PostLikeRequest request = PostLikeRequest.builder()
+        .isLiked(true)
+        .build();
+
+    // when, then
+    assertThrows(BadLikeException.class, () -> request.validate(postLike));
+  }
+}

--- a/src/test/java/com/blog/tanylog/postLike/service/PostLikeServiceTest.java
+++ b/src/test/java/com/blog/tanylog/postLike/service/PostLikeServiceTest.java
@@ -1,0 +1,119 @@
+package com.blog.tanylog.postLike.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blog.tanylog.config.DatabaseCleanup;
+import com.blog.tanylog.config.WithMockCustomUser;
+import com.blog.tanylog.config.security.UserContext;
+import com.blog.tanylog.post.domain.Post;
+import com.blog.tanylog.post.repository.PostRepository;
+import com.blog.tanylog.postLike.controller.dto.request.PostLikeRequest;
+import com.blog.tanylog.postLike.domain.PostLike;
+import com.blog.tanylog.postLike.repository.PostLikeRepository;
+import com.blog.tanylog.user.domain.Role;
+import com.blog.tanylog.user.domain.User;
+import com.blog.tanylog.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@SpringBootTest
+class PostLikeServiceTest {
+
+  @Autowired
+  private PostLikeService postLikeService;
+
+  @Autowired
+  private PostLikeRepository postLikeRepository;
+
+  @Autowired
+  private PostRepository postRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private DatabaseCleanup cleanup;
+
+  @BeforeEach
+  void saveDummyData() {
+    User user = User.builder()
+        .oauthId("dummy_oauthId")
+        .name("dummy_user")
+        .picture("dummy_picture")
+        .email("dummy_email")
+        .role(Role.USER).build();
+
+    userRepository.save(user);
+
+    Post post = Post.builder()
+        .title("dummy_title")
+        .content("dummy_content")
+        .isDeleted(false)
+        .build();
+
+    post.addUser(user);
+
+    postRepository.save(post);
+  }
+
+  @AfterEach
+  void clear() {
+    cleanup.execute();
+  }
+
+  @Test
+  @DisplayName("처음 게시글 좋아요를 누르면 좋아요 할 수 있습니다.")
+  @WithMockCustomUser
+  void 게시글_좋아요_등록() {
+    // given
+    UserContext userContext = (UserContext) SecurityContextHolder.getContext().getAuthentication()
+        .getPrincipal();
+    Long userId = userContext.getSessionUser().getUserId();
+
+    Long postId = 1L;
+
+    PostLikeRequest request = PostLikeRequest.builder().isLiked(false).build();
+
+    // when
+    postLikeService.saveOrDelete(postId, userContext, request);
+
+    // then
+    PostLike postLike = postLikeRepository.findPostLikeByPostIdAndUserId(postId, userId).get();
+
+    assertThat(postLike).isNotNull();
+    assertThat(postLike.getUser().getId()).isEqualTo(1L);
+    assertThat(postLike.getPost().getId()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("이미 좋아요 한 게시글에 좋아요를 누르면 좋아요가 취소됩니다.")
+  @WithMockCustomUser
+  void 게시글_좋아요_취소() {
+    // given
+    UserContext userContext = (UserContext) SecurityContextHolder.getContext().getAuthentication()
+        .getPrincipal();
+    Long userId = userContext.getSessionUser().getUserId();
+
+    Long postId = 1L;
+
+    PostLikeRequest saveRequest = PostLikeRequest.builder().isLiked(false).build();
+
+    PostLikeRequest cancelRequest = PostLikeRequest.builder().isLiked(true).build();
+
+    postLikeService.saveOrDelete(postId, userContext, saveRequest);
+
+    // when
+    postLikeService.saveOrDelete(postId, userContext, cancelRequest);
+
+    // then
+    PostLike postLike = postLikeRepository.findPostLikeByPostIdAndUserId(postId, userId)
+        .orElse(null);
+
+    assertThat(postLike).isNull();
+  }
+}


### PR DESCRIPTION
commit 805c3be4971da8116f25c5b8eac2102f16bba2ae (HEAD -> develop, origin/develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Aug 22 20:11:24 2023 +0900

    ## 게시글 전체 조회 API 검색 기능 추가

    ### Description
    - 게시글 검색 시 작성자 이름, 게시글 제목, 게시글 내용으로 조회할 수 있도록 전체 조회 API 로직 추가

commit 66c081436f28a341a03d733260c56a75e53e085b
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Aug 22 18:11:17 2023 +0900

    ## 좋아요 API 테스트 작성

    ### Description
    - 좋아요 API Controller, Request DTO, Service 테스트 작성

commit 46b4b27e10e4c48586e7c52d1b839b1dcaadad31
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Aug 22 18:10:28 2023 +0900

    ## 댓글 Controller 테스트 로직 수정

    ### Description
    - 댓글 수정 API URL 변경으로 로직 수정

commit f68ce125f62a3d8c6800120337066b0f7d0e0c8b
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Aug 22 18:09:44 2023 +0900

    ## Exception Controller 로직 추가

    ### Description
    - 좋아요 Entity 에 user_id, post_id unique 제약조건 추가로 인해 동시 좋아요 API 호출 시 발생할 수 있는 예외 처리 Handler 추가

commit ec555a3f22ca123547f9e979a9f9ee75f537733d
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Aug 22 18:08:47 2023 +0900

    ## 좋아요 API 메서드 네이밍 변경, Service 로직 및 PostLike Entity 수정

    ### Description
    - save() 에서 saveOrDelete() 로 변경
    - findPostLike 변수로 한 번만 조회하고 사용하도록 변경
    - PostLike 의 user_id, post_id 에 unique 제약 조건 추가

commit 8164234b3745eb0431a90d0b2dc1a422b778005b
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Tue Aug 22 18:05:45 2023 +0900

    ## 좋아요 Request DTO 네이밍 변경 및 Custom Exception 클래스 생성

    ### Description
    - IllegalArgumentException 대신 BadLikeException 사용하도록 클래스 추가 및 로직 변경