### PR TITLE
내가 작성한 글 조회 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/blog/tanylog/config/security/SecurityConfig.java
+++ b/src/main/java/com/blog/tanylog/config/security/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.POST, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.DELETE, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.PUT, "/posts/**").hasAnyRole("ADMIN", "USER")
+        .antMatchers(HttpMethod.GET, "/posts/my_posts").hasAnyRole("ADMIN", "USER")
 
         .antMatchers(HttpMethod.DELETE, "/comments/**").hasAnyRole("ADMIN", "USER")
         .anyRequest().permitAll()

--- a/src/main/java/com/blog/tanylog/post/controller/PostController.java
+++ b/src/main/java/com/blog/tanylog/post/controller/PostController.java
@@ -63,4 +63,12 @@ public class PostController {
 
     return ResponseEntity.ok(response);
   }
+
+  @GetMapping("/posts/my_posts")
+  public ResponseEntity<PostMultiReadResponse> readMyPosts(@ModelAttribute PageSearch pageSearch,
+      @AuthenticationPrincipal UserContext userContext) {
+    PostMultiReadResponse response = postService.readMyPosts(pageSearch, userContext);
+
+    return ResponseEntity.ok(response);
+  }
 }

--- a/src/main/java/com/blog/tanylog/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/blog/tanylog/post/repository/PostCustomRepository.java
@@ -1,5 +1,6 @@
 package com.blog.tanylog.post.repository;
 
+import com.blog.tanylog.config.security.UserContext;
 import com.blog.tanylog.post.controller.dto.request.PageSearch;
 import com.blog.tanylog.post.domain.Post;
 import java.util.List;
@@ -9,4 +10,7 @@ public interface PostCustomRepository {
   List<Post> readAll(PageSearch pageSearch);
 
   List<Post> readNoOffset(PageSearch pageSearch);
+
+  List<Post> readMyPosts(PageSearch pageSearch, UserContext userContext);
+
 }

--- a/src/main/java/com/blog/tanylog/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/blog/tanylog/post/repository/PostRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.blog.tanylog.post.repository;
 
+import com.blog.tanylog.config.security.UserContext;
 import com.blog.tanylog.post.controller.dto.request.PageSearch;
 import com.blog.tanylog.post.domain.Post;
 import com.blog.tanylog.post.domain.QPost;
@@ -95,6 +96,19 @@ public class PostRepositoryImpl implements PostCustomRepository {
         .where(dynamicLtId.and(QPost.post.isDeleted.eq(false)))
         .orderBy(QPost.post.id.desc())
         .limit(pageSearch.getSize())
+        .fetch();
+  }
+
+  @Override
+  public List<Post> readMyPosts(PageSearch pageSearch, UserContext userContext) {
+    return jpaQueryFactory.selectFrom(QPost.post)
+        .join(QPost.post.user)
+        .fetchJoin()
+        .where(QPost.post.isDeleted.eq(false),
+            QPost.post.user.id.eq(userContext.getSessionUser().getUserId()))
+        .limit(pageSearch.getSize())
+        .offset(pageSearch.getOffset())
+        .orderBy(QPost.post.id.desc())
         .fetch();
   }
 }

--- a/src/main/java/com/blog/tanylog/post/service/PostService.java
+++ b/src/main/java/com/blog/tanylog/post/service/PostService.java
@@ -125,8 +125,26 @@ public class PostService {
   @Transactional(readOnly = true)
   public PostMultiReadResponse readAll(PageSearch pageSearch) {
     List<Post> offset = postRepository.readAll(pageSearch);
+    List<PostSingleReadResponse> response = postToSingleReadResponse(offset);
 
-    List<PostSingleReadResponse> response = offset.stream()
+    return PostMultiReadResponse
+        .builder()
+        .postsResponse(response)
+        .build();
+  }
+
+  @Transactional(readOnly = true)
+  public PostMultiReadResponse readMyPosts(PageSearch pageSearch, UserContext userContext) {
+    List<Post> myPosts = postRepository.readMyPosts(pageSearch, userContext);
+    List<PostSingleReadResponse> response = postToSingleReadResponse(myPosts);
+
+    return PostMultiReadResponse.builder()
+        .postsResponse(response)
+        .build();
+  }
+
+  private List<PostSingleReadResponse> postToSingleReadResponse(List<Post> posts) {
+    return posts.stream()
         .map(post -> PostSingleReadResponse.builder()
             .id(post.getId())
             .title(post.getTitle())
@@ -140,10 +158,5 @@ public class PostService {
                 .build())
             .build())
         .collect(Collectors.toList());
-
-    return PostMultiReadResponse
-        .builder()
-        .postsResponse(response)
-        .build();
   }
 }

--- a/src/test/java/com/blog/tanylog/config/TestSecurityConfig.java
+++ b/src/test/java/com/blog/tanylog/config/TestSecurityConfig.java
@@ -22,6 +22,7 @@ public class TestSecurityConfig {
         .antMatchers(HttpMethod.POST, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.DELETE, "/posts/**").hasAnyRole("ADMIN", "USER")
         .antMatchers(HttpMethod.PUT, "/posts/**").hasAnyRole("ADMIN", "USER")
+        .antMatchers(HttpMethod.GET, "/posts/my_posts").hasAnyRole("ADMIN", "USER")
 
         .antMatchers(HttpMethod.DELETE, "/comments/**").hasAnyRole("ADMIN", "USER")
         .anyRequest().permitAll()

--- a/src/test/java/com/blog/tanylog/post/controller/PostControllerTest.java
+++ b/src/test/java/com/blog/tanylog/post/controller/PostControllerTest.java
@@ -2,6 +2,7 @@ package com.blog.tanylog.post.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -62,6 +63,15 @@ class PostControllerTest {
     Long postId = 1L;
 
     mockMvc.perform(put("/posts/{postId}", postId)
+            .with(csrf()))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  @DisplayName("비회원 상태로 내 게시물을 확인할 수는 없습니다.")
+  void 비회원_본인_게시글_조회_Redirect() throws Exception {
+    mockMvc.perform(get("/posts/my_posts")
             .with(csrf()))
         .andDo(print())
         .andExpect(status().is3xxRedirection());

--- a/src/test/java/com/blog/tanylog/post/service/PagingTest.java
+++ b/src/test/java/com/blog/tanylog/post/service/PagingTest.java
@@ -21,7 +21,7 @@ class PagingTest {
   @DisplayName("Offset 방식으로 게시글 전체 조회 API 페이징 성능을 테스트합니다.")
   void 게시글_전체조회_Offset() {
     // given
-    PageSearch pageSearch = new PageSearch(1L, 4000, 20);
+    PageSearch pageSearch = new PageSearch(null, 4000, 20, "", "");
 
     // when
     long startTime = System.currentTimeMillis();
@@ -38,7 +38,7 @@ class PagingTest {
   @DisplayName("No - Offset 방식으로 게시글 전체 조회 API 페이징 성능을 테스트합니다.")
   void 게시글_전체조회_No_Offset() {
     // given
-    PageSearch pageSearch = new PageSearch(5000L, 1, 20);
+    PageSearch pageSearch = new PageSearch(5000L, 1, 20, "", "");
 
     // when
     long startTime = System.currentTimeMillis();


### PR DESCRIPTION
commit 8599ac5b757a11490207069d9aac5a264d553004 (HEAD -> develop, origin/develop)
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Aug 24 17:59:40 2023 +0900

    ## 내가 작성한 글 조회 API Controller, Sevice 테스트 작성

    ### Description
    - 비회원인 경우 /loginForm 으로 Redirect
    - 권한을 가진 유저의 경우 페이징 처리되어 조회되는지 테스트
    - 기존 조회 API 와는 다르게 권한이 있어야하므로 Security Config 권한 설정 추가

commit 0d0993ab3d75afa32ef471ea1f4060ca2e54fdaa
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Aug 24 17:30:30 2023 +0900

    ## 내가 작성한 글 조회 API 구

    ### Description
    - 기존 조회 API 와는 다르게 권한을 가진 회원만이 조회할 수 있기 때문에 기존 조회 API 와 따로 분리해서 구현
    - 기존 조회 API 와 동일하게 Offset 방식으로 페이징 처리
    - List<Post> 타입 객체를 List<PostSingleReadResponse> DTO 타입으로 변환하는 공통 로직을 postToSingleReadResponse() 메서드로 분리
    - Security Config 권한 수정

commit 5f9ec0b9acb799e36382299ed879bcee614c4b48
Author: ByeoungJoon Jeon <juni8453@naver.com>
Date:   Thu Aug 24 17:27:41 2023 +0900

    ## Paging Test 수정

    ### Description
    - 검색 기능 추가로 PageSearch 생성자 변동으로 인해 PagingTest 일부 수정